### PR TITLE
Add support for build concurrency

### DIFF
--- a/needy/__main__.py
+++ b/needy/__main__.py
@@ -13,8 +13,21 @@ def satisfy(args=[]):
         description='Satisfies library and universal binary needs.',
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    parser.add_argument('--target', default='host', help='builds needs for this target (example: ios:armv7)')
-    parser.add_argument('--universal-binary', help='builds the universal binary with the given name')
+    parser.add_argument(
+        '--target',
+        default='host',
+        help='builds needs for this target (example: ios:armv7)')
+    parser.add_argument(
+        '--universal-binary',
+        help='builds the universal binary with the given name')
+    parser.add_argument(
+        '--jobs',
+        dest='build_concurrency',
+        default=1,
+        const=0,
+        nargs='?',
+        type=int,
+        help='number of jobs to process concurrently')
     for platform in available_platforms():
         platform.add_arguments(parser)
     parameters = parser.parse_args(args)

--- a/needy/needy.py
+++ b/needy/needy.py
@@ -3,6 +3,7 @@
 import json
 import os
 import subprocess
+import multiprocessing
 
 from colorama import Fore
 
@@ -26,6 +27,11 @@ class Needy:
 
     def parameters(self):
         return self.__parameters
+
+    def build_concurrency(self):
+        if self.parameters().build_concurrency > 0:
+            return self.parameters().build_concurrency
+        return multiprocessing.cpu_count()
 
     def platform(self, identifier):
         for platform in available_platforms():

--- a/needy/project.py
+++ b/needy/project.py
@@ -64,6 +64,12 @@ class Project:
             return self.__definition.configuration[key]
         return None
 
+    def build_concurrency(self):
+        concurrency = self.needy.build_concurrency()
+        if self.configuration('max-concurrency') is not None:
+            concurrency = min(concurrency, self.configuration('max-concurrency'))
+        return concurrency
+
     def pre_build(self, output_directory):
         pre_build_commands = self.configuration('pre-build') or []
         for command in pre_build_commands:

--- a/needy/projects/autotools.py
+++ b/needy/projects/autotools.py
@@ -4,6 +4,8 @@ import subprocess
 from .. import project
 from ..cd import cd
 
+import make
+
 
 class AutotoolsProject(project.Project):
 
@@ -98,7 +100,7 @@ class AutotoolsProject(project.Project):
         subprocess.check_call(['./configure'] + configure_args)
 
     def build(self, output_directory):
-        make_args = []
+        make_args = make.get_make_jobs_args(self)
 
         binary_paths = self.target().platform.binary_paths(self.target().architecture)
         if len(binary_paths) > 0:

--- a/needy/projects/boostbuild.py
+++ b/needy/projects/boostbuild.py
@@ -10,8 +10,18 @@ class BoostBuildProject(project.Project):
     def is_valid_project(definition):
         return definition.target.platform.identifier() is 'host' and os.path.isfile('Jamroot') and (os.path.isfile('b2') or subprocess.check_output(['b2', '-v']))
 
+    def get_build_concurrency_args(self):
+        concurrency = self.build_concurrency()
+
+        if concurrency > 1:
+            return ['-j', str(concurrency)]
+        elif concurrency == 0:
+            return ['-j']
+        return []
+
     def build(self, output_directory):
         b2 = './b2' if os.path.isfile('b2') else 'b2'
         b2_args = self.configuration('b2-args') or []
+        b2_args += self.get_build_concurrency_args()
         subprocess.check_call([b2] + b2_args)
         subprocess.check_call([b2, 'install', '--prefix=%s' % output_directory] + b2_args)

--- a/needy/projects/make.py
+++ b/needy/projects/make.py
@@ -5,6 +5,19 @@ import subprocess
 from .. import project
 
 
+# TODO: This really should be part of the MakeProject class, but
+#       other build systems still use some of the MakeProject
+#       arguments and parameters such as AutotoolsProject.
+def get_make_jobs_args(project):
+    concurrency = project.build_concurrency()
+
+    if concurrency > 1:
+        return ['-j', str(concurrency)]
+    elif concurrency == 0:
+        return ['-j']
+    return []
+
+
 class MakeProject(project.Project):
 
     @staticmethod
@@ -52,6 +65,8 @@ class MakeProject(project.Project):
     def build(self, output_directory):
 
         make_args = ['-f', './MakefileNeedyGenerated']
+        make_args += get_make_jobs_args(self)
+
         path_override = None
 
         target_os = None

--- a/tests/postgresql/needs.json
+++ b/tests/postgresql/needs.json
@@ -4,6 +4,7 @@
 			"repository": "git://git.postgresql.org/git/postgresql.git",
 			"commit": "0ed1e572b644e064e480e14d2f6afe03d11638a7",
 			"project": {
+				"max-concurrency": 1,
 				"conditionals": [
 					{
 						"platform": "host",

--- a/tests/run-all.py
+++ b/tests/run-all.py
@@ -9,6 +9,7 @@ import sys
 TESTS_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 TOP_LEVEL_DIRECTORY = os.path.dirname(TESTS_DIRECTORY)
 
+
 def test(directory, needy_args, run_dirty=False):
     print 'Running test in %s: %s' % (directory, ' '.join(needy_args))
     os.chdir(directory)
@@ -18,11 +19,12 @@ def test(directory, needy_args, run_dirty=False):
     env['PYTHONPATH'] = TOP_LEVEL_DIRECTORY
     subprocess.check_call(['python', '-m', 'needy', 'satisfy'] + needy_args, env=env)
 
+
 def main(args):
     parser = argparse.ArgumentParser(description='Tests Needy.')
     parser.add_argument('--run-dirty', default=False, action='store_true', help='run without cleaning first (useful for saving time while debugging)')
     parameters, needy_args = parser.parse_known_args(args[1:])
-    
+
     for entry in os.listdir(TESTS_DIRECTORY):
         test_directory = os.path.join(TESTS_DIRECTORY, entry)
         if os.path.isfile(os.path.join(test_directory, 'needs.json')):


### PR DESCRIPTION
This patch provides support for concurrent builds with Make and Boost
Build with a similar mechanism to the -j parameter. By specifying
--jobs on the command line with an optional number, Needy will provide
the appropriate parameter to Make or Boost Build.

In the event that a particular library can't be build using multiple
jobs, but other libraries can, a maximum number of jobs can be
specified in the configuration for that library using the 'max-jobs'
parameter. See the PostgreSQL example for details.