### PR TITLE
Fix Boost example

### DIFF
--- a/tests/boost/needs.json
+++ b/tests/boost/needs.json
@@ -3,10 +3,10 @@
 		"boost": {
 			"repository": "git@github.com:boostorg/boost.git",
 			"commit": "9ccd3390c8e9ef05f4cb681d15b2e14eac48886e",
-			"post-clean": [
-				"./bootstrap.sh"
-			],
 			"project": {
+				"post-clean": [
+					"./bootstrap.sh"
+				],
 				"b2-args": ["--with-filesystem"],
 				"conditionals": [
 					{


### PR DESCRIPTION
The post-clean configuration item should be located under the project
configuration and is innaccessible otherwise. This patch addresses the
issue by moving the configuration entry.