### PR TITLE
Fix recon with some make scripts

### DIFF
--- a/needy/projects/make.py
+++ b/needy/projects/make.py
@@ -120,6 +120,11 @@ class MakeProject(project.Project):
                 break
 
             path = match.group(1)
+
+            # shell scripts may contain special characters and probably won't be
+            # part of the resulting path.
+            path = path.rstrip(';"')
+
             if os.path.relpath(path, self.directory()).find('..') == 0:
                 if os.path.relpath(path, output_directory).find('..') == 0:
                     doing_things_outside_prefix = True


### PR DESCRIPTION
Some make scripts such as the one used by zlib have inline shell code
that includes the semicolon (;) delimiter but don't separate it from
file paths. Below is an example:

    -@if [ ...  ]; then mkdir -p $(DESTDIR)$(exec_prefix); fi

Currently, the regex expression we use to gauge the output of
`make --recon` to determine if the path is contained entirely within
our designated prefix will fail in some cases.

By stripping relatively "safe" characters from paths we find with our
regex expression, we are able to correctly process scripts like the
above at the cost of a little bit of accuracy in the cases where paths
actually do contain a trailing special characters. This patch only
strips semicolons ';' and double quotes (") in an effort to reduce the
need as much as possible.