### PR TITLE
Allow custom make prefix arguments

### DIFF
--- a/tests/zlib/needs.json
+++ b/tests/zlib/needs.json
@@ -1,0 +1,14 @@
+{
+	"libraries": {
+		"zlib": {
+			"download": "http://zlib.net/zlib-1.2.8.tar.gz",
+			"checksum": "44d667c142d7cda120332623eab69f40",
+			"project" : {
+				"post-clean": [
+					"./configure"
+				],
+				"make-prefix-arg": "prefix"
+			}
+		}
+	}
+}


### PR DESCRIPTION
Some projects such as lua use prefix variables that differ from the
established standards. In the case of LUA, the prefix is
"INSTALL_TOP". While it isn't economical to include all possible
prefix variables, it is desirable to be able to provide overrides
during certain parts of the build process.

Ideally, to accomplish this, configuration parameters would be
provided that are able to be passed to the appropriate subsystems.
Before this is possible, however, there needs to be a system of
variable substitution for configurations as this example requires not
only a custom installation argument, but also knowledge of where
exactly it is to be installed.

In the absence of this system, a single configuration parameter,
'make-prefix-arg' has added to support the specific use case of
non-standard prefix flags.