### PR TITLE
Allow custom build targets

### DIFF
--- a/needy/project.py
+++ b/needy/project.py
@@ -2,6 +2,7 @@ import os
 import shlex
 import subprocess
 
+
 # TODO: reevaluate where this function belongs
 def evaluate_conditionals(configuration, target):
     if 'conditionals' not in configuration:
@@ -74,6 +75,10 @@ class Project:
         if self.configuration('max-concurrency') is not None:
             concurrency = min(concurrency, self.configuration('max-concurrency'))
         return concurrency
+
+    def project_targets(self):
+        targets = self.configuration('project-targets')
+        return targets if targets is not None else []
 
     def pre_build(self, output_directory):
         pre_build_commands = self.configuration('pre-build') or []

--- a/needy/projects/autotools.py
+++ b/needy/projects/autotools.py
@@ -113,7 +113,7 @@ class AutotoolsProject(project.Project):
         if len(binary_paths) > 0:
             make_args.append('PATH=%s:%s' % (':'.join(binary_paths), os.environ['PATH']))
 
-        subprocess.check_call(['make'] + make_args)
+        subprocess.check_call(['make'] + self.project_targets() + make_args)
         subprocess.check_call(['make', 'install'] + make_args)
 
     def __available_configure_host(self, candidates):

--- a/needy/projects/make.py
+++ b/needy/projects/make.py
@@ -106,7 +106,7 @@ class MakeProject(project.Project):
             make_args.append('PATH=%s' % path_override)
             environment_overrides['PATH'] = path_override
 
-        self.needy.command(['make'] + make_args, environment_overrides=environment_overrides)
+        self.needy.command(['make'] + self.project_targets() + make_args, environment_overrides=environment_overrides)
 
         make_prefix_args = [
             'PREFIX=%s' % output_directory,

--- a/tests/lua/needs.json
+++ b/tests/lua/needs.json
@@ -1,0 +1,12 @@
+{
+	"libraries": {
+		"lua": {
+			"download": "http://www.lua.org/ftp/lua-5.2.1.tar.gz",
+			"checksum": "ae08f641b45d737d12d30291a5e5f6e3",
+			"project": {
+				"project-targets": ["generic"],
+				"make-prefix-arg": "INSTALL_TOP"
+			}
+		}
+	}
+}


### PR DESCRIPTION
With some projects, it's not desirable to build the entire thing. In
some other projects, a choice of targets is required such as with Lua.

To address this use case, a configuration item, "build-targets", has
been added where an array of targets can be specified. It is up to the
project type to properly make use of those targets if applicable.