### PR TITLE
Add dummy lib and include directories for each build

### DIFF
--- a/needy/generators/jamfile.py
+++ b/needy/generators/jamfile.py
@@ -62,7 +62,7 @@ rule needlib ( name : extra-sources * : requirements * : default-build * : usage
     local args = $(target) {satisfy_args} ;
     local builddir = [ SHELL "cd $(BASE_DIR) && $(NEEDY) builddir $(target)" ] ;
     local includedir = "$(builddir)/include" ;
-    
+
     make lib$(name).touch : $(NEEDS_FILE) : @satisfy-lib : $(requirements) <needyargs>$(args) ;
     actions satisfy-lib
     {{
@@ -70,9 +70,9 @@ rule needlib ( name : extra-sources * : requirements * : default-build * : usage
     }}
 
     alias $(name)
-        : $(extra-sources) 
-        : $(requirements) 
-        : $(default-build) 
+        : $(extra-sources)
+        : $(requirements)
+        : $(default-build)
         : <dependency>lib$(name).touch
           <include>$(includedir)
           <linkflags>-L$(builddir)/lib

--- a/needy/library.py
+++ b/needy/library.py
@@ -72,7 +72,7 @@ class Library:
         self.source.clean()
 
         configuration = self.project_configuration(target)
-        
+
         post_clean_commands = configuration['post-clean'] if 'post-clean' in configuration else []
         with cd(self.source_directory()):
             if isinstance(post_clean_commands, list):
@@ -93,7 +93,7 @@ class Library:
             shutil.rmtree(build_directory)
 
         os.makedirs(build_directory)
-        
+
         with cd(self.source_directory()):
             try:
                 project.configure(build_directory)
@@ -141,7 +141,7 @@ class Library:
 
         if os.path.exists(universal_binary_directory):
             shutil.rmtree(universal_binary_directory)
-            
+
         os.makedirs(universal_binary_directory)
 
         try:
@@ -191,9 +191,9 @@ class Library:
 
         if not os.path.isfile(self.build_status_path(target)):
             return False
-        
+
         configuration = self.project_configuration(target)
-        
+
         with open(self.build_status_path(target), 'r') as status_file:
             status_text = status_file.read()
             if not status_text.strip():
@@ -242,7 +242,7 @@ class Library:
             for candidate in candidates:
                 if candidate.identifier() == definition.configuration['type']:
                     return candidate(definition, self.needy)
-            raise RuntimeError('unknown project type') 
+            raise RuntimeError('unknown project type')
 
         scores = [(len(definition.configuration.viewkeys() & c.configuration_keys()), c) for c in candidates]
         candidates = [candidate for score, candidate in sorted(scores, key=itemgetter(0), reverse=True)]

--- a/needy/project.py
+++ b/needy/project.py
@@ -60,7 +60,7 @@ class Project:
         return self.__definition.directory
 
     def configuration(self, key=None):
-        if key == None:
+        if key is None:
             return self.__definition.configuration
         if key in self.__definition.configuration:
             return self.__definition.configuration[key]
@@ -77,8 +77,8 @@ class Project:
 
     def evaluate(self, str_or_list, build_directory):
         l = [] if not str_or_list else (str_or_list if isinstance(str_or_list, list) else [str_or_list])
-        return [str.format(build_directory=build_directory, 
-                           platform=self.target().platform.identifier(), 
+        return [str.format(build_directory=build_directory,
+                           platform=self.target().platform.identifier(),
                            architecture=self.target().architecture) for str in l]
 
     def run_commands(self, commands, build_directory):
@@ -114,6 +114,13 @@ class Project:
 
     def post_build(self, output_directory):
         self.run_commands(self.configuration('post-build'), output_directory)
+        build_dirs = [os.path.join(output_directory, d) for d in ['include', 'lib']]
+        self.__create_directories(build_dirs)
+
+    def __create_directories(self, dirs):
+        for d in dirs:
+            if not os.path.exists(d):
+                os.makedirs(d)
 
     def command(self, cmd, environment_overrides={}):
         env = environment_overrides.copy()

--- a/needy/projects/boostbuild.py
+++ b/needy/projects/boostbuild.py
@@ -14,10 +14,10 @@ class BoostBuildProject(project.Project):
     def is_valid_project(definition, needy):
         if not definition.target.platform.is_host():
             return False
-            
+
         if not os.path.isfile('Jamroot'):
             return False
-        
+
         if os.path.isfile('b2'):
             return True
 

--- a/tests/testinator/needs.json
+++ b/tests/testinator/needs.json
@@ -4,7 +4,8 @@
 			"repository": "git@github.com:elbeno/testinator.git",
 			"commit": "b6183c43718ccefb7896c47a1d4a9d89388890e7",
 			"project" : {
-				"source-directory": "src/include"
+				"header-directory": "src/include",
+				"source-directory": null
 			}
 		}
 	}


### PR DESCRIPTION
Previously, if a header-only library was used from a Needy-generated
Jamfile, there would be a warning about missing linker directories if
no "lib" directory existed in the build output. This patch ensure that the two
directories "include" and "lib" always exist in the build output--even if they
are empty.