### PR TITLE
Mirror directory structure when forming universal binaries

### DIFF
--- a/needy/platforms/osx.py
+++ b/needy/platforms/osx.py
@@ -2,6 +2,7 @@ from .xcode import XcodePlatform
 
 import platform
 
+
 class OSXPlatform(XcodePlatform):
     def __init__(self, parameters):
         XcodePlatform.__init__(self, parameters)
@@ -41,4 +42,3 @@ class OSXPlatform(XcodePlatform):
 
     def default_architecture(self):
         return platform.machine()
-

--- a/needy/platforms/tvos.py
+++ b/needy/platforms/tvos.py
@@ -1,5 +1,6 @@
 from .xcode import XcodePlatform
 
+
 class tvOSPlatform(XcodePlatform):
     def __init__(self, parameters):
         XcodePlatform.__init__(self, parameters)
@@ -31,6 +32,7 @@ class tvOSPlatform(XcodePlatform):
 
     def default_architecture(self):
         return 'arm64'
+
 
 class tvOSSimulatorPlatform(tvOSPlatform):
     def __init__(self, parameters):


### PR DESCRIPTION
Previously, universal binaries would not mirror the source directory
structure if the source structure included empty directories. This
causes problems when using providing LDFLAGS for header-only
directories and so to mitigate the issue, the source directory
structure is mirrored to the output.