### PR TITLE
Add diagnostic message to failed file locking

### DIFF
--- a/needy/__main__.py
+++ b/needy/__main__.py
@@ -184,7 +184,11 @@ Use '%s <command> --help' to get help for a specific command.
 
     lock_fd = os.open('.needy_lock', os.O_RDWR | os.O_CREAT)
     try:
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except IOError:
+            print('Waiting for other needy instances to terminate...')
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
         if parameters.command in commands:
             return commands[parameters.command](parameters.args)
         elif parameters.command == 'help':


### PR DESCRIPTION
Previously, if the .needy_lock file existed and was locked by another
process, Needy would block indefinitely with no error. This patch
adjusts that behavior so that instead of blocking indefinitely, Needy
will provide an appropriate error message and will terminate early.