### PR TITLE
Add needs_directory for Jinja templates

### DIFF
--- a/needy/needy.py
+++ b/needy/needy.py
@@ -73,7 +73,8 @@ class Needy:
                 platform=target.platform.identifier() if target else None,
                 architecture=target.architecture if target else None,
                 host_platform=host_platform().identifier(),
-                needs_file=self.needs_file()
+                needs_file=self.needs_file(),
+                needs_directory=self.needs_directory()
             )
         except ImportError:
             if re.compile('{%.*%}').search(configuration) or re.compile('{{.*}}').search(configuration) or re.compile('{#.*#}').search(configuration):


### PR DESCRIPTION
This patch provides the needs_directory variable which resolves to the
same path that Needy.needs_directory() resolves to--the path where all
Needy-managed libraries go. This is necessary in the case of wanting to
utilize another Needy-managed library's output.