### PR TITLE
Add better logging in some places

### DIFF
--- a/needy/needy.py
+++ b/needy/needy.py
@@ -4,6 +4,7 @@ import os
 import multiprocessing
 import re
 import sys
+import logging
 
 from collections import OrderedDict
 
@@ -31,16 +32,25 @@ class Needy:
         self.__path = path if os.path.isabs(path) else os.path.normpath(os.path.join(current_directory(), path))
         self.__parameters = parameters
 
-        self.__needs_directory = os.path.join(self.__path, 'needs')
         self.__needs_file = self.find_needs_file(self.__path)
+        self.__needs_directory = Needy.resolve_needs_directory(self.__path)
 
-        directory = self.__path
+        if self.__needs_file is None:
+            raise RuntimeError('No needs file found in {}'.format(self.__path))
+
+        logging.debug('Using needs file {}'.format(self.__needs_file))
+        logging.debug('Using needs directory {}'.format(self.__needs_directory))
+
+    @staticmethod
+    def resolve_needs_directory(directory):
+        ret = None
         while directory:
-            if self.find_needs_file(directory):
-                self.__needs_directory = os.path.join(directory, 'needs')
+            if Needy.find_needs_file(directory):
+                ret = os.path.join(directory, 'needs')
             directory = os.path.dirname(directory)
             if directory == os.sep:
                 break
+        return ret
 
     def path(self):
         return self.__path

--- a/needy/process.py
+++ b/needy/process.py
@@ -27,7 +27,7 @@ def __log_check_call(cmd, verbosity, **kwargs):
         if verbosity < logging.getLogger().getEffectiveLevel():
             subprocess.check_call(cmd, stderr=devnull, shell=shell, stdout=devnull, **kwargs)
         else:
-            subprocess.check_call(cmd, stderr=devnull, shell=shell, **kwargs)
+            subprocess.check_call(cmd, stderr=subprocess.STDOUT, shell=shell, **kwargs)
 
 
 def command(cmd, verbosity=logging.INFO, environment_overrides={}):


### PR DESCRIPTION
In an ongoing effort to improve needy's log output, several variables
and actions are now logged in this patch. In particular,
`process.__log_check_call` previously would not provide output stderr
of called commands. This patch fixes that oversight and now includes
stderr for command of the appropriate verbosity level.