### PR TITLE
Allow unsetting in environment variables overrides

### DIFF
--- a/needy/override_environment.py
+++ b/needy/override_environment.py
@@ -7,19 +7,22 @@ class OverrideEnvironment:
         self.__new_vals = vars_dict
         self.__added_vals = []
 
-        for k in vars_dict:
+        for k, v in vars_dict.items():
             if k in os.environ:
                 self.__old_vals[k] = os.environ[k]
-            else:
+            elif v is not None:
                 self.__added_vals += [k]
 
     def __enter__(self):
         for k, v in self.__new_vals.items():
-            os.environ[k] = v
+            if v is None:
+                if k in os.environ:
+                    del os.environ[k]
+            else:
+                os.environ[k] = v
 
     def __exit__(self, etype, value, traceback):
         for k, v in self.__old_vals.items():
-            if k in os.environ:
-                os.environ[k] = v
+            os.environ[k] = v
         for k in self.__added_vals:
             del os.environ[k]

--- a/tests/unit/test_override_environment.py
+++ b/tests/unit/test_override_environment.py
@@ -24,10 +24,28 @@ class OverrideEnvironmentTest(unittest.TestCase):
             'FOOBAR': 'foo'
         }
 
-        self.assertTrue('FOOBAR' not in os.environ)
+        self.assertFalse('FOOBAR' in os.environ)
 
         with OverrideEnvironment(overrides):
             for var in os.environ:
                 self.assertEqual(os.environ[var], 'foo' if var == 'FOOBAR' else previous_env[var])
+
+        self.assertEqual(os.environ, previous_env)
+
+    def test_unsets_values(self):
+        previous_env = os.environ.copy()
+        overrides = {
+            'PATH': None,
+            'FOOBAR': None
+        }
+
+        self.assertTrue('PATH' in os.environ)
+        self.assertFalse('FOOBAR' in os.environ)
+
+        with OverrideEnvironment(overrides):
+            self.assertFalse('PATH' in os.environ)
+            self.assertFalse('FOOBAR' in os.environ)
+            for var in os.environ:
+                self.assertEqual(os.environ[var], previous_env[var])
 
         self.assertEqual(os.environ, previous_env)


### PR DESCRIPTION
This patch allows environment variables to be unset using
OverrideEnvironment.