### PR TITLE
Prevent CC and CXX from being overridden with Xcode builds

### DIFF
--- a/needy/platforms/xcode.py
+++ b/needy/platforms/xcode.py
@@ -30,7 +30,7 @@ class XcodePlatform(Platform):
         return ' '.join(args)
 
     def c_compiler(self, architecture):
-        return 'xcrun -sdk %s clang %s' % (self.sdk(), self.__common_compiler_args(architecture))
+        return 'xcrun -sdk {} clang {}'.format(self.sdk(), self.__common_compiler_args(architecture))
 
     def cxx_compiler(self, architecture):
-        return 'xcrun -sdk %s clang++ %s' % (self.sdk(), self.__common_compiler_args(architecture))
+        return 'xcrun -sdk {} clang++ {}'.format(self.sdk(), self.__common_compiler_args(architecture))

--- a/needy/projects/xcode.py
+++ b/needy/projects/xcode.py
@@ -39,6 +39,14 @@ class XcodeProject(project.Project):
     def configuration_keys():
         return ['xcode-project']
 
+    def environment_overrides(self):
+        # CC and CXX will likely be correct when invoked by xcode directly
+        ret = project.Project.environment_overrides(self)
+        for var in ['CC', 'CXX']:
+            if var in ret:
+                del ret[var]
+        return ret
+
     def build(self, output_directory):
         xcodebuild_args = ['-parallelizeTargets', 'ONLY_ACTIVE_ARCH=YES', 'USE_HEADER_SYMLINKS=YES']
 


### PR DESCRIPTION
Previously, CC and CXX would be overridden to build a wide variety of
targets although this is likely undesirable behavior when building
Xcode projects as Xcode only supports a limited number of targets
and will typically pick the right settings to build for those targets.