### PR TITLE
Add build artifact caching

### DIFF
--- a/needy/build_cache.py
+++ b/needy/build_cache.py
@@ -1,0 +1,104 @@
+import logging
+import os
+import time
+import json
+
+from contextlib import contextmanager
+
+from .cache import Cache, Manifest
+from .filesystem import TempDir, dict_file
+
+
+class BuildCache:
+    def __init__(self, cache, lock_timeout=10, lifetime=2*7*24*60*60, gc_frequency=24*60*60):
+        self.__cache = cache
+        self.__lock_timeout = lock_timeout
+        self.__lifetime = lifetime
+        self.__gc_frequency = gc_frequency
+
+        with self.__load_cache_policies() as p:
+            if 'object_lifetime' not in p:
+                p['object_lifetime'] = self.__lifetime
+            if 'gc_frequency' not in p:
+                p['gc_frequency'] = self.__gc_frequency
+
+            self.__lifetime = p['object_lifetime']
+            self.__gc_frequency = p['gc_frequency']
+
+    @staticmethod
+    def manifest_key():
+        return '.manifest'
+
+    @staticmethod
+    def policy_key():
+        return '.policy'
+
+    @contextmanager
+    def __load_manifest(self):
+        try:
+            with self.__cache.lease_file(BuildCache.manifest_key(), timeout=self.__lock_timeout, create=True) as path:
+                with Manifest(path) as m:
+                    yield m
+        except:
+            logging.warn('cache unavailable: unable to load manifest')
+            raise
+
+    @contextmanager
+    def __load_cache_policies(self):
+        try:
+            with self.__cache.lease_file(BuildCache.policy_key(), timeout=self.__lock_timeout, create=True) as path:
+                with dict_file(path) as d:
+                    yield d
+        except:
+            logging.warn('key unavailable: unable to load policies')
+            raise
+
+    def manifest(self):
+        '''Returns manifest at call time. Manifest may change between calls'''
+        with self.__load_manifest() as m:
+            return m
+
+    def store_artifacts(self, directory, key):
+        '''Store artifacts to key. Makes liberal use of exceptions for errors.'''
+        logging.info('Storing build artifacts in cache')
+        try:
+            with self.__load_manifest() as m:
+                m.touch(key)
+                self.__collect_garbage(m)
+            with self.__cache.lease(key, create=True):
+                self.__cache.store_directory(directory, key, timeout=self.__lock_timeout)
+        except:
+            logging.info('key unavailable: failed to store artifacts')
+            raise
+
+    def load_artifacts(self, key, directory):
+        '''Loads artifacts from key. Makes liberal use of exceptions for errors.'''
+        logging.info('Loading artifacts to build directory')
+        try:
+            with self.__load_manifest() as m:
+                m.touch(key)
+                self.__collect_garbage(m)
+            with self.__cache.lease(key):
+                self.__cache.load_directory(key, directory, timeout=self.__lock_timeout)
+        except:
+            logging.warn('key unavailable: failed to load artifacts')
+            raise
+
+    def __collect_garbage(self, manifest):
+        last_gc_time = manifest.metadata()['last_gc_time'] if 'last_gc_time' in manifest.metadata() else None
+        if last_gc_time and last_gc_time + self.__gc_frequency > time.time():
+            return
+
+        min_time = time.time() - self.__lifetime
+
+        total = 0
+
+        for key in [k for k in manifest if manifest[k].use_time < min_time]:
+            try:
+                self.__cache.unset_key(key)
+                total += 1
+            except:
+                pass
+
+        if total:
+            logging.info('garbage collection removed {} expired keys'.format(total))

--- a/needy/cache.py
+++ b/needy/cache.py
@@ -1,0 +1,180 @@
+import tempfile
+import os
+import shutil
+import tarfile
+import json
+import logging
+import time
+
+from contextlib import contextmanager
+
+from .filesystem import TempDir
+
+
+class KeyLocked(Exception):
+    '''Raised when an action would read or modify a key that is locked'''
+    pass
+
+
+class SourceNotFound(Exception):
+    '''Raised when a source is required to exist and isn't found'''
+    pass
+
+
+class KeyNotFound(Exception):
+    '''Raised when a key is required to exist and isn't found'''
+    pass
+
+
+class Cache:
+    '''If concurrency for load and store methods is desired, utilize the
+    lock_key and unlock_key methods.'''
+
+    @staticmethod
+    def type():
+        '''type of cache'''
+        raise NotImplementedError('type')
+
+    def description(self):
+        '''uri, path, or other configuration description'''
+        raise NotImplementedError('description')
+
+    def to_dict(self):
+        '''export self to dictionary for serialization'''
+        raise NotImplementedError('to_dict')
+
+    @staticmethod
+    def from_dict(d):
+        '''inverse of to_dict. Should return a cache.'''
+        raise NotImplementedError('from_dict')
+
+    def store_directory(self, source, key, timeout=0):
+        '''make directory at source retrievable with the key'''
+        if not os.path.exists(source):
+            raise SourceNotFound(source)
+        temp_dir = tempfile.mkdtemp()
+        temp_tar = os.path.join(temp_dir, 'temp')
+        try:
+            tar = tarfile.open(temp_tar, 'w:gz')
+            tar.add(source, arcname='.')
+            tar.close()
+            self.store_file(temp_tar, key, timeout)
+        finally:
+            shutil.rmtree(temp_dir)
+
+    def load_directory(self, key, destination, timeout=0):
+        '''restore directory at key to destination'''
+        temp_dir = tempfile.mkdtemp()
+        temp_tar = os.path.join(temp_dir, key)
+        try:
+            self.load_file(key, temp_tar, timeout)
+            tar = tarfile.open(temp_tar, 'r:gz')
+            tar.extractall(path=destination)
+            tar.close()
+        finally:
+            shutil.rmtree(temp_dir)
+
+    def store_file(self, source, key, timeout=0):
+        '''make file at source retrievable with key.'''
+        raise NotImplementedError('store_file')
+
+    def load_file(self, key, destination, timeout=0):
+        '''restore file at key to destination'''
+        raise NotImplementedError('load_file')
+
+    def exists(self, key, timeout=0):
+        '''return true if artifacts at key exist'''
+        raise NotImplementedError('exists')
+
+    def lock_key(self, key, timeout=None, create=False):
+        '''lock key for exclusive use'''
+        raise NotImplementedError('lock_key')
+
+    def unlock_key(self, key):
+        '''unlock key for others to use'''
+        raise NotImplementedError('unlock_key')
+
+    def unset_key(self, key):
+        '''remove key from the cache'''
+        raise NotImplementedError('unset_key')
+
+    class Lease:
+        def __init__(self, cache, key, **kwargs):
+            self.__cache = cache
+            self.__key = key
+            self.__kwargs = kwargs
+
+        def __enter__(self):
+            self.__cache.lock_key(self.__key, **self.__kwargs)
+
+        def __exit__(self, etype, value, traceback):
+            self.__cache.unlock_key(self.__key)
+
+    def lease(self, key, **kwargs):
+        '''convenience wrapper around lock_key and unlock_key'''
+        return Cache.Lease(self, key, **kwargs)
+
+    @contextmanager
+    def lease_file(self, key, timeout=None, **kwargs):
+        '''convenience wrapper around lease a key, load a file to a temporary
+        directory, and then save modifications when the lease is returned. If
+        the path is removed during the lease, the key will be unset.'''
+        with self.lease(key, timeout=timeout, **kwargs):
+            with tempfile.NamedTemporaryFile() as f:
+                self.load_file(key, f.name, timeout=timeout)
+                yield f.name
+                if os.path.exists(f.name):
+                    self.store_file(f.name, key, timeout=timeout)
+                else:
+                    self.unset_key(f.name)
+
+
+class Manifest:
+    def __init__(self, path):
+        self.__path = path
+        self.__entries = dict()
+
+    class Entry:
+        def __init__(self, d=dict()):
+            self.use_time = int(d['use_time']) if 'use_time' in d else 0
+
+        def to_dict(self):
+            return {'use_time': self.use_time} if self.use_time > 0 else dict()
+
+    def __enter__(self):
+        with open(self.__path, 'r') as f:
+            contents = f.read()
+            d = (json.loads(contents) if contents else dict())
+            self.__metadata = {k: v for k, v in d['metadata'].items()} if 'metadata' in d else dict()
+            self.__entries = {k: Manifest.Entry(v) for k, v in d['keys'].items()} if 'keys' in d else dict()
+        return self
+
+    def __exit__(self, etype, value, traceback):
+        try:
+            with open(self.__path, 'w') as f:
+                d = dict()
+                if self.__metadata:
+                    d['metadata'] = self.__metadata
+                d['keys'] = {k: v.to_dict() for k, v in self.__entries.items()}
+                json.dump(d, f)
+        except:
+            logging.error('error storing manifest')
+            raise
+
+    def metadata(self):
+        return self.__metadata
+
+    def touch(self, key):
+        self.__entries[key] = Manifest.Entry({'use_time': int(time.time())})
+
+    def __delitem__(self, key):
+        del self.__entries[key]
+
+    def __contains__(self, key):
+        return self.__entries.__contains__(key)
+
+    def __getitem__(self, key):
+        return self.__entries.__getitem__(key)
+
+    def __iter__(self):
+        return self.__entries.__iter__()

--- a/needy/caches/directory.py
+++ b/needy/caches/directory.py
@@ -1,0 +1,99 @@
+import os
+import shutil
+import time
+import fcntl
+
+from ..cache import Cache, KeyLocked, SourceNotFound, KeyNotFound
+from ..filesystem import clean_file, lock_file
+
+
+class Directory(Cache):
+    def __init__(self, path):
+        self.__path = path
+        self.__locks = dict()
+
+    @staticmethod
+    def type():
+        return 'directory'
+
+    def to_dict(self):
+        return {'path': self.__path}
+
+    @staticmethod
+    def from_dict(d):
+        return Directory(path=d['path'])
+
+    def description(self):
+        return self.__path if self.__path else ''
+
+    def store_file(self, source, key, timeout=0):
+        destination_file = self.__archive_path(key)
+        if not os.path.exists(source):
+            raise SourceNotFound(source)
+        try:
+            clean_file(destination_file)
+            shutil.copyfile(source, destination_file)
+        except IOError:
+            if key in self.__locks:
+                raise
+            else:
+                raise KeyLocked(key)
+
+    def load_file(self, key, destination, timeout=0):
+        try:
+            clean_file(destination)
+            # Race condition between checking for existence and actually trying
+            # the copy. Both will throw, but in the case where we lose the race,
+            # the raised error will be a KeyLocked as opposed to a KeyNotFound.
+            if not os.path.exists(self.__archive_path(key)):
+                raise KeyNotFound(key)
+            shutil.copyfile(self.__archive_path(key), destination)
+        except IOError as e:
+            raise KeyLocked(key, e)
+
+    def exists(self, key):
+        try:
+            return os.path.exists(self.__archive_path(key))
+        except IOError:
+            if key in self.__locks:
+                raise
+            else:
+                raise KeyLocked(key)
+
+    def __archive_path(self, key=None):
+        root = self.__path
+        return os.path.join(root, key) if key else root
+
+    def lock_key(self, key, timeout=None, create=False):
+        if not create and not os.path.exists(self.__archive_path(key)):
+            raise KeyNotFound(key)
+
+        if create:
+            try:
+                os.makedirs(os.path.dirname(self.__archive_path(key)))
+            except:
+                pass
+
+        fd = lock_file(self.__archive_path(key), timeout)
+        if fd:
+            self.__locks[key] = fd
+        else:
+            raise KeyLocked(key)
+
+    def unlock_key(self, key):
+        if key in self.__locks:
+            os.close(self.__locks[key])
+        else:
+            raise KeyNotFound(key)
+
+    def unset_key(self, key):
+        if not os.path.exists(self.__archive_path(key)):
+            return
+        try:
+            os.remove(self.__archive_path(key))
+        except IOError:
+            # TODO: how to determine errors for other reasons?
+            if key in self.__locks:
+                raise
+            else:
+                raise KeyLocked(key)

--- a/needy/needy.py
+++ b/needy/needy.py
@@ -25,6 +25,7 @@ from .platform import available_platforms, host_platform
 from .generator import available_generators
 from .target import Target
 from .cd import current_directory
+from .cache import Cache
 
 
 class Needy:
@@ -111,6 +112,9 @@ class Needy:
             print('Development mode {}enabled for {}: {}'.format('already ' if was_already else '', library_name, self.source_directory(library_name)))
         else:
             print('Development mode {}disabled for {}. Please ensure that you have persisted any changes you wish to keep.'.format('already ' if was_already else '', library_name))
+
+    def cache(self):
+        return self.__local_configuration.cache() if self.__local_configuration else None
 
     def needs_configuration(self, target=None):
         configuration = ''

--- a/tests/functional/test_cache.py
+++ b/tests/functional/test_cache.py
@@ -1,0 +1,55 @@
+import json
+import os
+import time
+import shutil
+
+from .functional_test import TestCase
+from needy.filesystem import dict_file, TempDir
+
+
+class DirectoryCacheTest(TestCase):
+    def test_satisfy(self):
+        with TempDir() as cache_dir:
+            with dict_file(os.path.join(self.path(), 'needs.json')) as d:
+                d['libraries'] = {
+                    'lua': {
+                        'download': 'http://www.lua.org/ftp/lua-5.2.1.tar.gz',
+                        'checksum': '6bb1b0a39b6a5484b71a83323c690154f86b2021',
+                        'project': {
+                            'make-targets': 'generic',
+                            'make-prefix-arg': 'INSTALL_TOP',
+                        }
+                    }
+                }
+
+            self.assertEqual(self.execute(['cache', 'query']), 0)
+            self.assertEqual(self.execute(['cache', 'set', cache_dir]), 0)
+            self.assertEqual(self.execute(['cache', 'query']), 0)
+            start = time.time()
+            self.assertEqual(self.execute(['satisfy', '-v']), 0)
+            uncached_time = time.time() - start
+
+            def check_output():
+                self.assertTrue(os.path.isfile(os.path.join(self.build_directory('lua'), 'include', 'lua.h')))
+                self.assertTrue(os.path.isfile(os.path.join(self.build_directory('lua'), 'lib', 'liblua.a')))
+                self.assertTrue('lua' in os.listdir(cache_dir))
+                self.assertTrue('.manifest' in os.listdir(cache_dir))
+                self.assertTrue('.policy' in os.listdir(cache_dir))
+
+                with dict_file(os.path.join(cache_dir, '.manifest')) as d:
+                    self.assertGreater(len(d['keys']), 0)
+
+            check_output()
+
+            shutil.rmtree(self.build_directory('lua'))
+
+            cached_start = time.time()
+            self.assertEqual(self.satisfy(), 0)
+            cached_time = time.time() - cached_start
+
+            check_output()
+
+            self.assertGreater(uncached_time, cached_time)
+            self.assertLess(cached_time, 2)
+
+            self.assertEqual(self.execute(['cache', 'unset']), 0)

--- a/tests/unit/caches/test_directory.py
+++ b/tests/unit/caches/test_directory.py
@@ -1,0 +1,183 @@
+import unittest
+import os
+import shutil
+import multiprocessing
+import sys
+
+from needy.caches.directory import Directory
+from needy.cache import SourceNotFound, KeyNotFound
+from needy.filesystem import TempDir
+
+
+class DirectoryTest(unittest.TestCase):
+    def test_file_store_load(self):
+        with TempDir() as cache_dir, TempDir() as d:
+            cache = Directory(path=cache_dir)
+
+            foo_file = os.path.join(d, 'foo_file')
+            bar_file = os.path.join(d, 'bar_file')
+
+            with open(foo_file, 'w') as f:
+                f.write('foo')
+            with open(bar_file, 'w') as f:
+                f.write('bar')
+
+            self.assertFalse(os.listdir(cache_dir))
+
+            cache.store_file(foo_file, 'foo_key')
+            cache.store_file(bar_file, 'bar_key')
+
+            self.assertTrue(os.listdir(cache_dir))
+
+            os.remove(foo_file)
+            os.remove(bar_file)
+
+            cache.load_file('foo_key', foo_file)
+            cache.load_file('bar_key', bar_file)
+
+            with open(foo_file, 'r') as f:
+                self.assertEqual(f.read(), 'foo')
+            with open(bar_file, 'r') as f:
+                self.assertEqual(f.read(), 'bar')
+
+    def test_directory_store_load(self):
+        with TempDir() as cache_dir, TempDir() as d:
+            cache = Directory(path=cache_dir)
+
+            foo_file = os.path.join(d, 'foo_file')
+            bar_file = os.path.join(d, 'bar_file')
+
+            with open(foo_file, 'w') as f:
+                f.write('foo')
+            with open(bar_file, 'w') as f:
+                f.write('bar')
+
+            self.assertFalse(os.listdir(cache_dir))
+
+            cache.store_directory(d, 'foo_key')
+
+            self.assertTrue(os.listdir(cache_dir))
+
+            shutil.rmtree(d)
+
+            cache.load_directory('foo_key', d)
+
+            with open(foo_file, 'r') as f:
+                self.assertEqual(f.read(), 'foo')
+            with open(bar_file, 'r') as f:
+                self.assertEqual(f.read(), 'bar')
+
+    def test_store_raise_error_on_invalid_path(self):
+        with TempDir() as cache_dir, TempDir() as d:
+            cache = Directory(path=cache_dir)
+
+            not_file = os.path.join(d, 'doesnt_exist')
+            self.assertRaises(SourceNotFound, lambda: cache.store_file(not_file, 'key'))
+
+    def test_load_raise_error_on_invalid_key(self):
+        with TempDir() as cache_dir, TempDir() as d:
+            cache = Directory(path=cache_dir)
+
+            destination = os.path.join(d, 'build_directory')
+            self.assertRaises(KeyNotFound, lambda: cache.load_file('key', destination))
+
+    def test_key_lock_unlock(self):
+        with TempDir() as cache_dir, TempDir() as d:
+            cache = Directory(path=cache_dir)
+
+            foo_file = os.path.join(d, 'foo_file')
+            with open(foo_file, 'w') as f:
+                f.write('foo')
+            key = 'foo_key'
+            cache.store_file(foo_file, key)
+
+            self.assertTrue(self.try_lock_from_another_process(cache_dir, key))
+
+            with cache.lease(key):
+                self.assertFalse(self.try_lock_from_another_process(cache_dir, key))
+
+            self.assertTrue(self.try_lock_from_another_process(cache_dir, key))
+
+    def test_key_lock_creates(self):
+        with TempDir() as cache_dir, TempDir() as d:
+            cache = Directory(path=cache_dir)
+
+            key = 'foo_key'
+            self.assertFalse(cache.exists(key))
+
+            with cache.lease(key, create=True):
+                self.assertTrue(cache.exists(key))
+
+            self.assertTrue(cache.exists(key))
+            self.assertTrue(os.listdir(cache_dir))
+
+    @staticmethod
+    def try_lock_from_another_process(cache_dir, key):
+        def run(cache_dir, key):
+            cache = Directory(path=cache_dir)
+            try:
+                cache.lock_key(key, timeout=0)
+                cache.unlock_key(key)
+            except:
+                sys.exit(1)
+            sys.exit(0)
+
+        process = multiprocessing.Process(target=run, args=(cache_dir, key))
+        process.start()
+        process.join()
+        return process.exitcode == 0
+
+    def test_key_exists(self):
+        with TempDir() as cache_dir, TempDir() as d:
+            cache = Directory(path=cache_dir)
+
+            foo_file = os.path.join(d, 'foo_file')
+            with open(foo_file, 'w') as f:
+                f.write('foo')
+            key = 'foo_key'
+
+            self.assertFalse(cache.exists(key))
+            cache.store_file(foo_file, key)
+            self.assertTrue(cache.exists(key))
+
+    def test_key_unset(self):
+        with TempDir() as cache_dir, TempDir() as d:
+            cache = Directory(path=cache_dir)
+
+            foo_file = os.path.join(d, 'foo_file')
+            with open(foo_file, 'w') as f:
+                f.write('foo')
+            key = 'foo_key'
+            cache.store_file(foo_file, key)
+
+            self.assertTrue(cache.exists(key))
+            cache.unset_key(key)
+            self.assertFalse(cache.exists(key))
+
+    def test_raises_with_key_lock_unlock_on_invalid_path(self):
+        with TempDir() as cache_dir:
+            cache = Directory(path=cache_dir)
+            self.assertRaises(KeyNotFound, lambda: cache.lock_key('doesntexist'))
+            self.assertRaises(KeyNotFound, lambda: cache.unlock_key('doesntexist'))
+
+    def test_lease_file(self):
+        with TempDir() as cache_dir:
+            cache = Directory(path=cache_dir)
+
+            key = 'foo'
+
+            self.assertFalse(cache.exists(key))
+
+            with cache.lease_file(key, create=True) as path:
+                self.assertTrue(cache.exists(key))
+                self.assertTrue(os.path.exists(path))
+                with open(path, 'r') as f:
+                    self.assertNotEqual(f.read(), key)
+                with open(path, 'w') as f:
+                    f.write(key)
+
+            self.assertTrue(cache.exists(key))
+
+            with cache.lease_file(key) as path:
+                with open(path, 'r') as f:
+                    self.assertEqual(f.read(), key)

--- a/tests/unit/test_build_cache.py
+++ b/tests/unit/test_build_cache.py
@@ -1,0 +1,109 @@
+import unittest
+import os
+import shutil
+
+from time import sleep
+
+from needy.build_cache import BuildCache
+from needy.filesystem import TempDir
+from needy.caches.directory import Directory
+from needy.cache import SourceNotFound, KeyNotFound
+
+
+class BuildCacheTest(unittest.TestCase):
+    def test_creates_manifest_if_necessary(self):
+        with TempDir() as cache_dir:
+            build_cache = BuildCache(Directory(path=cache_dir))
+
+            with TempDir() as build_dir:
+                open(os.path.join(build_dir, 'foo'), 'a').close()
+                self.assertTrue(os.listdir(build_dir))
+                build_cache.store_artifacts(build_dir, 'foo')
+                self.assertTrue(os.listdir(cache_dir))
+
+    def test_store_load_artifacts(self):
+        with TempDir() as cache_dir:
+            build_cache = BuildCache(Directory(path=cache_dir))
+
+            with TempDir() as build_dir:
+                for name in ['f1', 'f2', 'dir1/f3']:
+                    path = os.path.join(build_dir, name)
+                    try:
+                        os.makedirs(os.path.dirname(path))
+                    except:
+                        pass
+                    with open(path, 'w') as f:
+                        f.write(name)
+
+                build_cache.store_artifacts(build_dir, 'foo')
+
+            with TempDir() as temp:
+                build_cache.load_artifacts('foo', os.path.join(temp, 'build_dir'))
+                for name in ['f1', 'f2', 'dir1/f3']:
+                    path = os.path.join(temp, 'build_dir', name)
+                    with open(path, 'r') as f:
+                        self.assertEqual(f.read(), name)
+
+    def test_store_adds_entries_to_manifest(self):
+        with TempDir() as cache_dir:
+            build_cache = BuildCache(Directory(path=cache_dir))
+
+            self.assertTrue('foo' not in build_cache.manifest())
+
+            with TempDir() as build_dir:
+                build_cache.store_artifacts(build_dir, 'foo')
+
+            self.assertTrue('foo' in build_cache.manifest())
+
+
+    def test_store_raises_with_invalid_source(self):
+        with TempDir() as cache_dir:
+            build_cache = BuildCache(Directory(path=cache_dir))
+
+            self.assertRaises(SourceNotFound, lambda: build_cache.store_artifacts(os.path.join(cache_dir, 'doesnt_exist'), 'foo'))
+
+    def test_load_raises_with_invalid_key(self):
+        with TempDir() as cache_dir:
+            build_cache = BuildCache(Directory(path=cache_dir))
+
+            with TempDir() as d:
+                self.assertRaises(KeyNotFound, lambda: build_cache.load_artifacts('foo', os.path.join(d, 'dest')))
+
+    def test_creates_cache_policies(self):
+        with TempDir() as cache_dir, TempDir() as d:
+            build_cache = BuildCache(Directory(path=cache_dir), lifetime=5)
+            self.assertTrue(BuildCache.policy_key() in os.listdir(cache_dir))
+
+        with TempDir() as cache_dir, TempDir() as d:
+            build_cache = BuildCache(Directory(path=cache_dir))
+            self.assertTrue(BuildCache.policy_key() in os.listdir(cache_dir))
+
+        with TempDir() as cache_dir, TempDir() as d:
+            build_cache = BuildCache(Directory(path=os.path.join(cache_dir, 'cache')))
+            self.assertTrue(BuildCache.policy_key() in os.listdir(os.path.join(cache_dir, 'cache')))
+
+    def test_load_increases_lifetime(self):
+        with TempDir() as cache_dir, TempDir() as d:
+            build_cache = BuildCache(Directory(path=cache_dir), lifetime=5)
+
+            build_cache.store_artifacts(d, 'foo')
+            previous_use_time = build_cache.manifest()['foo'].use_time
+
+            self.assertNotEqual(previous_use_time, 0)
+            sleep(3)
+
+            build_cache.load_artifacts('foo', os.path.join(d, 'temp'))
+            self.assertGreater(build_cache.manifest()['foo'].use_time, previous_use_time)
+
+    def test_garbage_collection(self):
+        with TempDir() as cache_dir, TempDir() as d:
+            cache = BuildCache(Directory(path=cache_dir), lifetime=2, gc_frequency=0)
+
+            cache.store_artifacts(d, 'foo_key')
+            self.assertTrue('foo_key' in os.listdir(cache_dir))
+            sleep(4)
+
+            cache.store_artifacts(d, 'bar_key')
+            self.assertFalse('foo_key' in os.listdir(cache_dir))
+            self.assertTrue('bar_key' in os.listdir(cache_dir))
+            sleep(4)

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,0 +1,76 @@
+import unittest
+
+from pyfakefs import fake_filesystem_unittest
+
+from needy.cache import Manifest
+
+
+class ManifestEntry(unittest.TestCase):
+    def test_serialization(self):
+        entry = {'use_time': 5}
+        self.assertEqual(Manifest.Entry(entry).use_time, 5)
+        self.assertEqual(Manifest.Entry().use_time, 0)
+        self.assertEqual(entry, Manifest.Entry(entry).to_dict())
+        self.assertEqual(Manifest.Entry({'use_time': 0}).to_dict(), dict())
+
+
+class ManifestTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
+    def test_load_store_manifest_contents(self):
+        path = '/tmp/manifest'
+        self.fs.CreateFile(path, contents='{"keys": {"foo": {}}}')
+
+        with Manifest(path) as m:
+            self.assertTrue('foo' in m)
+            del m['foo']
+            m.touch('bar')
+
+        with open(path, 'r') as f:
+            self.assertRegexpMatches(f.read(), '{"keys": {"bar": {"use_time": [0-9]*}}}')
+
+    def test_use_time(self):
+        path = '/tmp/manifest'
+        self.fs.CreateFile(path, contents='{"keys": {"foo": {"use_time": 1234}}}')
+
+        with Manifest(path) as m:
+            self.assertEqual(m['foo'].use_time, 1234)
+            m['foo'].use_time = 2345
+
+        with open(path, 'r') as f:
+            self.assertEqual(f.read(), '{"keys": {"foo": {"use_time": 2345}}}')
+
+    def test_touch(self):
+        path = '/tmp/manifest'
+        self.fs.CreateFile(path)
+
+        with Manifest(path) as m:
+            m.touch('foo')
+
+        with open(path, 'r') as f:
+            self.assertRegexpMatches(f.read(), '{"keys": {"foo": {"use_time": [0-9]*}}}')
+
+    def test_remove_key(self):
+        path = '/tmp/manifest'
+        self.fs.CreateFile(path, contents='{"keys": {"foo": {"use_time": 1234}}}')
+
+        with Manifest(path) as m:
+            del m['foo']
+
+        with open(path, 'r') as f:
+            self.assertEqual(f.read(), '{"keys": {}}')
+
+    def test_metadata(self):
+        path = '/tmp/manifest'
+        self.fs.CreateFile(path, contents='{"metadata": {"foo": "bar"}}')
+
+        with Manifest(path) as m:
+            self.assertEqual(m.metadata()['foo'], 'bar')
+            del m.metadata()['foo']
+            m.metadata()['bar'] = 'foo'
+
+        with open(path, 'r') as f:
+            content = f.read()
+            self.assertRegexpMatches(content, '"keys": {}')
+            self.assertRegexpMatches(content, '"metadata": {"bar": "foo"}')

--- a/tests/unit/test_filesystem.py
+++ b/tests/unit/test_filesystem.py
@@ -5,19 +5,18 @@ import shutil
 import multiprocessing
 import sys
 
-from needy.filesystem import lock_file
+from pyfakefs import fake_filesystem_unittest
+
+from needy.filesystem import lock_file, clean_file, clean_directory, TempDir, dict_file
 
 
 class FilesystemTest(unittest.TestCase):
     def test_lock_file_non_blocking(self):
-        directory = tempfile.mkdtemp()
-        path = os.path.join(directory, 'tempfile')
-        try:
+        with TempDir() as d:
+            path = os.path.join(d, 'tempfile')
             fd = lock_file(path, timeout=0)
             self.assertTrue(fd)
             self.assertFalse(self.try_access_from_other_process(path))
-        finally:
-            shutil.rmtree(directory)
 
     @staticmethod
     def try_access_from_other_process(path):
@@ -29,12 +28,75 @@ class FilesystemTest(unittest.TestCase):
         process.join()
         return process.exitcode == 0
 
-    def test_lock_file_is_exclusive_inside_process(self):
-        directory = tempfile.mkdtemp()
-        path = os.path.join(directory, 'tempfile')
-        try:
+    def test_lock_file_shares_exclusive_lock_inside_process(self):
+        with TempDir() as d:
+            path = os.path.join(d, 'tempfile')
             fd = lock_file(path, timeout=2)
             self.assertTrue(fd)
-            self.assertFalse(lock_file(path, timeout=0))
-        finally:
-            shutil.rmtree(directory)
+            os.close(fd)
+            self.assertTrue(lock_file(path, timeout=0))
+
+
+class FakeFilesystemTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
+    def test_clean_directory_creates_parents(self):
+        clean_directory('/tmp/dirty-dir')
+
+        self.assertTrue(os.path.exists('/tmp/dirty-dir'))
+        self.assertFalse(os.listdir('/tmp/dirty-dir'))
+
+    def test_clean_directory_removes_contents(self):
+        self.fs.CreateFile('/tmp/dirty-dir/file1')
+        self.fs.CreateFile('/tmp/dirty-dir/file2')
+        self.fs.CreateDirectory('/tmp/dirty-dir/dir1')
+        self.fs.CreateFile('/tmp/dirty-dir/dir1/file3')
+        clean_directory('/tmp/dirty-dir')
+
+        self.assertTrue(os.path.exists('/tmp/dirty-dir'))
+        self.assertFalse(os.listdir('/tmp/dirty-dir'))
+
+    def test_clean_file_creates_parents(self):
+        clean_file('/tmp/dirty-dir/file')
+
+        self.assertTrue(os.path.exists('/tmp/dirty-dir'))
+        self.assertFalse(os.listdir('/tmp/dirty-dir'))
+
+    def test_clean_file_removes_file(self):
+        self.fs.CreateFile('/tmp/dirty-dir/file1')
+        self.fs.CreateFile('/tmp/dirty-dir/file2')
+        self.fs.CreateDirectory('/tmp/dirty-dir/dir1')
+        self.fs.CreateFile('/tmp/dirty-dir/dir1/file3')
+        clean_file('/tmp/dirty-dir/file1')
+
+        self.assertTrue(os.path.exists('/tmp/dirty-dir'))
+        self.assertEqual(set(os.listdir('/tmp/dirty-dir')), set(['file2', 'dir1']))
+
+    def test_temp_dir(self):
+        path = ''
+        with TempDir() as d:
+            path = d
+            self.assertTrue(os.path.exists(path))
+            self.assertFalse(os.listdir(path))
+        self.assertFalse(os.path.exists(path))
+
+    def test_file_dict_load_store(self):
+        self.fs.CreateFile('/tmp/file', contents='{"foo": 1}')
+
+        with dict_file('/tmp/file') as d:
+            self.assertEqual(d['foo'], 1)
+            del d['foo']
+            d['bar'] = 'test'
+
+        with open('/tmp/file') as f:
+            self.assertEqual(f.read(), '{"bar": "test"}')
+
+    def test_file_dict_creates_file(self):
+        self.fs.CreateDirectory('/tmp')
+
+        with dict_file('/tmp/file') as d:
+            d['bar'] = 'test'
+
+        with open('/tmp/file') as f:
+            self.assertEqual(f.read(), '{"bar": "test"}')

--- a/tests/unit/test_library.py
+++ b/tests/unit/test_library.py
@@ -40,19 +40,3 @@ class LibraryTest(fake_filesystem_unittest.TestCase):
             self.assertTrue('prefix=/' in contents)
             self.assertTrue('-la' in contents)
             self.assertTrue('-lb' in contents)
-
-    def test_clean_directory_creates_directory(self):
-        Library.clean_directory('/tmp/dirty-dir')
-
-        self.assertTrue(os.path.exists('/tmp/dirty-dir'))
-        self.assertFalse(os.listdir('/tmp/dirty-dir'))
-
-    def test_clean_directory_removes_contents(self):
-        self.fs.CreateFile('/tmp/dirty-dir/file1')
-        self.fs.CreateFile('/tmp/dirty-dir/file2')
-        self.fs.CreateDirectory('/tmp/dirty-dir/dir1')
-        self.fs.CreateFile('/tmp/dirty-dir/dir1/file3')
-        Library.clean_directory('/tmp/dirty-dir')
-
-        self.assertTrue(os.path.exists('/tmp/dirty-dir'))
-        self.assertFalse(os.listdir('/tmp/dirty-dir'))


### PR DESCRIPTION
This patch introduces caching that can be made available with `needy cache-path set [path]` and acts as a key/value store to archive the contents of the build directory after builds. When the cache contains artifacts for a particular build, they are used instead of going through the build process.