### PR TITLE
Add clean command and don't clean build directories in dev-mode

### DIFF
--- a/needy/command.py
+++ b/needy/command.py
@@ -68,7 +68,8 @@ def universal_binary_completer(prefix, parsed_args, **kwargs):
         return [name for name in needy.universal_binary_names() if name.startswith(prefix)]
 
 
-def add_target_specification_args(parser, action='executes'):
+def add_target_specification_args(parser, action='executes', allow_universal_binary=True):
     parser.add_argument('-t', '--target', default='host', help='{} for this target (example: ios:armv7)'.format(action)).completer = target_completer
-    parser.add_argument('-u', '--universal-binary', help='{} for the universal binary with the given name'.format(action)).completer = universal_binary_completer
+    if allow_universal_binary:
+        parser.add_argument('-u', '--universal-binary', help='{} for the universal binary with the given name'.format(action)).completer = universal_binary_completer
     parser.add_argument('-D', '--define', nargs='*', action='append', help='specify a user-defined variable to be passed to the needs file renderer')

--- a/needy/commands/__init__.py
+++ b/needy/commands/__init__.py
@@ -6,6 +6,7 @@ def available_commands():
         ('.builddir', 'BuildDirCommand'),
         ('.cflags', 'CFlagsCommand'),
         ('.dev', 'DevCommand'),
+        ('.clean', 'CleanCommand'),
         ('.exec', 'ExecCommand'),
         ('.generate', 'GenerateCommand'),
         ('.init', 'InitCommand'),

--- a/needy/commands/clean.py
+++ b/needy/commands/clean.py
@@ -1,0 +1,22 @@
+from __future__ import print_function
+
+from .. import command
+from ..needy import ConfiguredNeedy
+
+
+class CleanCommand(command.Command):
+    def name(self):
+        return 'clean'
+
+    def add_parser(self, group):
+        short_description = 'clean a need'
+        parser = group.add_parser(self.name(), description=short_description.capitalize()+'.', help=short_description)
+        parser.add_argument('library', default=None, nargs='*', help='the library to clean. shell-style wildcards are allowed').completer = command.library_completer
+        parser.add_argument('-f', '--force', action='store_true', help='ignore warnings')
+        parser.add_argument('-b', '--build-directory', action='store_true', help='only clean build directories')
+        command.add_target_specification_args(parser, 'gets the directory')
+
+    def execute(self, arguments):
+        with ConfiguredNeedy('.', arguments) as needy:
+            needy.clean(needy.target(arguments.target), arguments.library, only_build_directory=arguments.build_directory, force=arguments.force)
+        return 0

--- a/needy/commands/init.py
+++ b/needy/commands/init.py
@@ -18,8 +18,7 @@ class InitCommand(command.Command):
             help='initializes library source directories'
         )
         parser.add_argument('library', default=None, nargs='*', help='the library to initialize the source of. shell-style wildcards are allowed').completer = command.library_completer
-        parser.add_argument('-t', '--target', default='host', help='initialize the source for this target (example: ios:armv7)').completer = command.target_completer
-        parser.add_argument('-D', '--define', nargs='*', action='append', help='specify a user-defined variable to be passed to the needs file renderer')
+        command.add_target_specification_args(parser, 'initializes the source directory', allow_universal_binary=False)
 
     def execute(self, arguments):
         with ConfiguredNeedy('.', arguments) as needy:

--- a/needy/library.py
+++ b/needy/library.py
@@ -85,6 +85,9 @@ class Library:
         source = self.source()
         source.clean()
 
+    def clean_build(self):
+        clean_directory(self.build_directory())
+
     def initialize_source(self):
         self.clean_source()
         with OverrideEnvironment(self.__environment_overrides()):
@@ -134,7 +137,8 @@ class Library:
 
             project.set_string_format_variables(**self.string_format_variables())
 
-            clean_directory(self.build_directory())
+            if not self.is_in_development_mode():
+                self.clean_build()
 
             self.__actualize(project)
             self.__write_build_status()
@@ -170,12 +174,13 @@ class Library:
                 raise
 
     def __write_build_status(self):
-        if self.is_in_development_mode():
-            return
         with open(self.build_status_path(), 'w') as status_file:
-            status = {
-                'configuration': binascii.hexlify(self.configuration_hash()).decode()
-            }
+            if self.is_in_development_mode():
+                status = {}
+            else:
+                status = {
+                    'configuration': binascii.hexlify(self.configuration_hash()).decode()
+                }
             json.dump(status, status_file)
 
     def __cache_artifacts(self):

--- a/needy/sources/download.py
+++ b/needy/sources/download.py
@@ -11,6 +11,7 @@ import tarfile
 import tempfile
 import time
 import zipfile
+import logging
 
 try:
     import urllib.request as urllib2
@@ -39,7 +40,7 @@ class Download(Source):
 
         self.__fetch()
 
-        print('Unpacking to %s' % self.destination)
+        logging.info('Unpacking to %s' % self.destination)
         self.__clean_destination_dir()
         self.__unpack()
         self.__trim_lone_dirs()
@@ -53,7 +54,7 @@ class Download(Source):
 
     @classmethod
     def get(cls, url, checksum, destination):
-        print('Downloading from %s' % url)
+        logging.info('Downloading from %s' % url)
         download = None
         attempts = 0
         download_successful = False
@@ -61,13 +62,13 @@ class Download(Source):
             try:
                 download = urllib2.urlopen(url, timeout=5)
             except urllib2.URLError as e:
-                print(e)
+                logging.warning(e)
             except socket.timeout as e:
-                print(e)
+                logging.warning(e)
             attempts = attempts + 1
             download_successful = download and download.code == 200 and 'content-length' in download.info()
             if not download_successful:
-                print('Download failed. Retrying...')
+                logging.warning('Download failed. Retrying...')
             time.sleep(attempts)
         if not download_successful:
             raise IOError('unable to download library')
@@ -95,10 +96,10 @@ class Download(Source):
                 print('\r       \r', end='')
                 sys.stdout.flush()
 
-            print('Verifying checksum...')
+            logging.debug('Verifying checksum...')
             if not cls.verify_checksum(local_file.name, checksum):
                 raise ValueError('incorrect checksum')
-            print('Checksum verified.')
+            logging.debug('Checksum verified.')
 
             shutil.move(local_file.name, destination)
         except:


### PR DESCRIPTION
In order to facilitate faster incremental builds, satisfy no longer cleans build directories for dev-mode libraries. To facilitate clean builds, the clean command has been introduced which will clean source and build directories for specific libraries.