### PR TITLE
Fix repository changes for git sources

### DIFF
--- a/tests/functional/sources/test_git.py
+++ b/tests/functional/sources/test_git.py
@@ -1,0 +1,40 @@
+import json
+import os
+import sys
+
+from ..functional_test import TestCase
+
+
+class GitTest(TestCase):
+    def test_source_change(self):
+        with open(os.path.join(self.path(), 'needs.json'), 'w') as needs_file:
+            needs_file.write(json.dumps({
+                'libraries': {
+                    'miniupnpc': {
+                        'repository': 'https://github.com/miniupnp/miniupnp.git',
+                        'commit': 'miniupnpc_1_8',
+                        'project': {
+                            'build-steps': [
+                                'echo noop'
+                            ]
+                        }
+                    }
+                }
+            }))
+        self.assertEqual(self.satisfy(), 0)
+
+        with open(os.path.join(self.path(), 'needs.json'), 'w') as needs_file:
+            needs_file.write(json.dumps({
+                'libraries': {
+                    'miniupnpc': {
+                        'repository': 'https://github.com/miniupnp/libnatpmp.git',
+                        'commit': '16434170ca6d46c9a92cc99118745e2f43ecae99',
+                        'project': {
+                            'build-steps': [
+                                'echo noop'
+                            ]
+                        }
+                    }
+                }
+            }))
+        self.assertEqual(self.satisfy(), 0)


### PR DESCRIPTION
Previously, when a git source changed from one repo url to another, needy would not properly update the url. This patch fixes the issue by allowing needy to do so when it detects that a remote has changed.