### PR TITLE
Make Xcode project post-processing more robust

### DIFF
--- a/needy/library.py
+++ b/needy/library.py
@@ -326,7 +326,7 @@ class Library:
 
     @classmethod
     def build_compatibility(cls):
-        return 4
+        return 5
 
     def configuration_hash(self):
         hash = hashlib.sha256()

--- a/needy/projects/xcode.py
+++ b/needy/projects/xcode.py
@@ -5,6 +5,7 @@ import logging
 
 from .. import project
 from ..cd import cd
+from ..filesystem import copy_if_changed
 from ..process import command_output
 from ..platforms.xcode import XcodePlatform
 
@@ -84,7 +85,7 @@ class XcodeProject(project.Project):
         for file in os.listdir(extras_build_dir):
             name, extension = os.path.splitext(file)
             if extension in lib_extensions:
-                shutil.move(os.path.join(extras_build_dir, file), lib_directory)
+                copy_if_changed(os.path.join(extras_build_dir, file), lib_directory)
 
         if not os.listdir(extras_build_dir):
             os.rmdir(extras_build_dir)


### PR DESCRIPTION
Previously, when an Xcode project had development mode enabled, it would sporadically fail the build steps due to preconditions not being met for shutil.move. To avoid the issue and make Xcode projects more robust, a copy_if_changed function has been added to allow copying of assets that actually change in order to preserve timestamps for unmodified build files.